### PR TITLE
moved the xib file to the podspec resources section

### DIFF
--- a/SJNotificationViewController.podspec
+++ b/SJNotificationViewController.podspec
@@ -6,7 +6,8 @@ Pod::Spec.new do |s|
   s.author   = { 'Scott Jackson' => 'scottjacksonx@gmail.com' }
   s.source   = { :git => 'git://github.com/scottjacksonx/SJNotificationViewController.git', :tag => '1.1' }
   s.homepage = 'http://github.com/scottjacksonx/SJNotificationViewController'
-  s.source_files = 'SJNotificationViewController{.h,.m,.xib}'
+  s.source_files = 'SJNotificationViewController{.h,.m}'
+  s.resources = ['SJNotificationViewController.xib']
   s.framework = 'QuartzCore'
 
   s.platform = :ios


### PR DESCRIPTION
Was getting the following error when building a project using this pod:
Unable to run command 'StripNIB SJNotificationViewController.nib' - this target might include its own product.
moving the xib file to the resources section from the source files fixed it
